### PR TITLE
修复搜狗导入bug: 横杠bug,文件编码bug

### DIFF
--- a/rimetool/utils/encoding_test.py
+++ b/rimetool/utils/encoding_test.py
@@ -1,0 +1,17 @@
+import chardet
+
+
+def detect_file_encoding(input_file):
+    encoding = None
+    try:
+        # 确保 gbk 文件和 utf8 文件都能正确读入
+        with open(input_file, 'rb') as file:
+            raw_data = file.read()
+            # 检测文件编码
+            result = chardet.detect(raw_data)
+            encoding = result['encoding']
+            confidence = result['confidence']
+            print(f"检测到的编码格式: {encoding}，置信度: {confidence}")
+    except FileNotFoundError:
+        print("文件未找到，请检查文件路径。")
+    return encoding

--- a/rimetool/utils/singlechinese.py
+++ b/rimetool/utils/singlechinese.py
@@ -1,6 +1,7 @@
 import os
 from pypinyin import lazy_pinyin
 from datetime import datetime
+from .encoding_test import detect_file_encoding
 
 roman_to_chinese = {
     'Ⅰ': '一', 'Ⅱ': '二', 'Ⅲ': '三', 'Ⅳ': '四', 'Ⅴ': '五',
@@ -21,9 +22,12 @@ def replace_roman_with_chinese(text):
     return text
 
 def main(input_file, output_path):
+	# 确保文件编码正确读入，并在输出时转为gbk
+	encoding = detect_file_encoding(input_file)
+	
 	current_time = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
 	output_file = os.path.join(output_path, f'singlechinese_output.dict.yaml')
-	with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
+	with open(input_file, 'r', encoding=encoding) as infile, open(output_file, 'w', encoding='gbk') as outfile:
 		outfile.write(
 			"# 生成工具 https://github.com/whitewatercn/rimetool\n" +
 			"# 生成时间 " + current_time + "\n" +

--- a/rimetool/utils/tosougou.py
+++ b/rimetool/utils/tosougou.py
@@ -1,16 +1,20 @@
 from datetime import datetime
 import re
 import os
+from .encoding_test import detect_file_encoding
 
 def main(input_file, output_path):
+	encoding = detect_file_encoding(input_file)
 	current_time = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
 	output_file = os.path.join(output_path, f'tosougou_output.txt')
 
-	with open(input_file, 'r') as infile, open(output_file, 'w+') as outfile:
+	with open(input_file, 'r', encoding=encoding) as infile, open(output_file, 'w+', encoding=encoding) as outfile:
 		outfile.write(
 			"# 生成工具 https://github.com/whitewatercn/rimetool\n" +
-			"# 生成时间 " + current_time + "\n" +
-			"---\n"
+			"# 生成时间 " + current_time + "\n" 
+			# 搜狗输入法导入时，识别"---"会报错
+			# +
+			# "---\n"
 		)
 		for line in infile:
 			content = line.strip()

--- a/rimetool/utils/vcf.py
+++ b/rimetool/utils/vcf.py
@@ -1,13 +1,16 @@
 import os
 from pypinyin import lazy_pinyin
 from datetime import datetime
+from .encoding_test import detect_file_encoding
 
 def main(input_file, output_path):
+    # 确保文件编码正确读入，并在输出时转为gbk
+    encoding = detect_file_encoding(input_file)
 
     current_time = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
     output_file = os.path.join(output_path, f'vcf_contact_output.dict.yaml')
     # 从vcf文件中提取联系人姓名
-    with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
+    with open(input_file, 'r', encoding=encoding) as infile, open(output_file, 'w', encoding='gbk') as outfile:
         outfile.write(
             "# 生成工具 https://github.com/whitewatercn/rimetool\n" +
             "# 生成时间 " + current_time + "\n" +


### PR DESCRIPTION
开发环境：Windows 11

搜狗输入导入词库遇到"---"横杠，会报错，在 tosogou.py 中删去；
vcf 和 singlechinese 涉及到编码问题，可能会使命令无法运行，或者在搜狗导入时出现乱码。经排查发现，先识别当前 encoding 并输入，再统一用 gbk 输出，可以保证导入搜狗无bug。